### PR TITLE
API: 마이페이지, 내 정보 수정

### DIFF
--- a/src/pages/user/EditMyPage.jsx
+++ b/src/pages/user/EditMyPage.jsx
@@ -22,13 +22,11 @@ const EditMyPage = () => {
   const { showAlert } = useAlert();
   const { user, setUser } = useUser();
 
-  // 이메일 제외한 정보는 수정 가능
   const [name, setName] = useState(user.name);
   const [email] = useState(user.email); // 읽기 전용
   const [password, setPassword] = useState('');
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
 
-  const emailRegex = /^[A-Za-z0-9@._-]+$/;
   const passwordRegex = /^[A-Za-z0-9!@#$%^&*]*$/;
 
   const handleNameChange = (e) => {
@@ -56,7 +54,6 @@ const EditMyPage = () => {
     showAlert('수정을 취소하시겠습니까?', () => navigate('/mypage'), '확인');
   };
 
-  // 저장 버튼 (서버에 PATCH 요청)
   const handleSave = async () => {
     if (!name.trim()) {
       showAlert('닉네임을 입력해주세요.');
@@ -79,29 +76,25 @@ const EditMyPage = () => {
       return;
     }
 
-    // 서버에 PATCH 요청
-    // setUser({
-    //   ...user,
-    //   name,
-    // });
-
     try {
+      const token = localStorage.getItem('access_token');
+      const config = {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      };
       const data = {
         name: name,
         email: email,
         password: password,
         passwordConfirmation: passwordConfirmation,
       };
-      console.log('전송할 data:', data);
 
-      const response = await api.patch('/api/user-info', data);
-
+      const response = await api.patch('/api/user-info', data, config);
       if (response.data.success) {
         setUser({
           ...user,
           name,
-          password,
-          passwordConfirmation,
         });
         showAlert(
           '프로필 수정이 완료되었습니다!',
@@ -117,7 +110,6 @@ const EditMyPage = () => {
     }
   };
 
-  // 이름, 비밀번호, 비밀번호 확인 모두 입력해야 저장 가능
   const isSaveDisabled =
     !name.trim() || !password.trim() || !passwordConfirmation.trim();
 

--- a/src/pages/user/MyPage.jsx
+++ b/src/pages/user/MyPage.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAlert } from '../../context/AlertContext';
-import { useUser } from '../../context/UserContext'; // 추가
+import { useUser } from '../../context/UserContext';
 import Header from '../../components/Header';
 import TextField from '../../components/user/TextField';
 import ProfileLogo from '../../assets/img/logo/ProfileLogo.png';
@@ -19,7 +19,7 @@ import {
 const MyPage = () => {
   const navigate = useNavigate();
   const { showAlert } = useAlert();
-  const { user, setUser } = useUser(); // 전역 user 상태에서 name, email, password를 꺼냄
+  const { user, setUser } = useUser();
 
   useEffect(() => {
     console.log('user: ', user);
@@ -38,55 +38,30 @@ const MyPage = () => {
             ...prev,
           }));
         } else {
-          showAlert('회원 정보 조회에 실패하였습니다.1');
+          showAlert('회원 정보 조회에 실패하였습니다.');
         }
       } catch (error) {
         console.log('error: ', error);
-        showAlert('회원 정보 조회에 실패하였습니다.2');
+        showAlert('회원 정보 조회에 실패하였습니다.');
       }
     };
-
     getMyInfo();
   }, []);
-
-  // const handleLogout = () => {
-  //   showAlert(
-  //     '로그아웃 하시겠습니까?',
-  //     () => {
-  //       try {
-  //         const res = api.post('/api/auth/logout');
-  //         if (res.data.success) {
-  //           showAlert('성공적으로 로그아웃 되었습니다.');
-  //           localStorage.clear;
-  //         }
-  //       } catch (error) {
-  //         showAlert('로그아웃에 실패했습니다. 다시 시도해주세요.');
-  //       }
-  //       navigate('/mypage');
-  //     },
-  //     '확인',
-  //   );
-  // };
 
   const handleLogout = () => {
     showAlert('로그아웃 하시겠습니까?', async () => {
       try {
-        // 토큰 가져오기 (예: localStorage에서)
         const token = localStorage.getItem('access_token');
-        // Authorization 헤더 설정
         const config = {
           headers: {
             Authorization: token,
           },
         };
 
-        // POST 요청 시 config 전달
         const response = await api.post('/api/auth/logout', {}, config);
         if (response.data.success) {
-          showAlert('성공적으로 로그아웃 되었습니다.', () =>
-            navigate('/login'),
-          );
-          // 로컬 스토리지 및 전역 상태 정리
+          showAlert('성공적으로 로그아웃 되었습니다.');
+          navigate('/login');
           localStorage.clear();
           setUser({
             name: '',

--- a/src/pages/user/MyPage.jsx
+++ b/src/pages/user/MyPage.jsx
@@ -49,23 +49,56 @@ const MyPage = () => {
     getMyInfo();
   }, []);
 
+  // const handleLogout = () => {
+  //   showAlert(
+  //     '로그아웃 하시겠습니까?',
+  //     () => {
+  //       try {
+  //         const res = api.post('/api/auth/logout');
+  //         if (res.data.success) {
+  //           showAlert('성공적으로 로그아웃 되었습니다.');
+  //           localStorage.clear;
+  //         }
+  //       } catch (error) {
+  //         showAlert('로그아웃에 실패했습니다. 다시 시도해주세요.');
+  //       }
+  //       navigate('/mypage');
+  //     },
+  //     '확인',
+  //   );
+  // };
+
   const handleLogout = () => {
-    showAlert(
-      '로그아웃 하시겠습니까?',
-      () => {
-        try {
-          const res = api.post('/api/auth/logout');
-          if (res.data.success) {
-            showAlert('성공적으로 로그아웃 되었습니다.');
-            localStorage.clear;
-          }
-        } catch (error) {
-          showAlert('로그아웃에 실패했습니다. 다시 시도해주세요.');
+    showAlert('로그아웃 하시겠습니까?', async () => {
+      try {
+        // 토큰 가져오기 (예: localStorage에서)
+        const token = localStorage.getItem('access_token');
+        // Authorization 헤더 설정
+        const config = {
+          headers: {
+            Authorization: token,
+          },
+        };
+
+        // POST 요청 시 config 전달
+        const response = await api.post('/api/auth/logout', {}, config);
+        if (response.data.success) {
+          showAlert('성공적으로 로그아웃 되었습니다.', () =>
+            navigate('/login'),
+          );
+          // 로컬 스토리지 및 전역 상태 정리
+          localStorage.clear();
+          setUser({
+            name: '',
+            email: '',
+          });
         }
-        navigate('/mypage');
-      },
-      '확인',
-    );
+      } catch (error) {
+        showAlert('로그아웃에 실패했습니다. 다시 시도해주세요.', () =>
+          navigate('/mypage'),
+        );
+      }
+    });
   };
 
   const handleEdit = () => {


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 🔁 반영 브랜치

- develop <- api/32-mypage

### 📜 작업내용

- 내 정보 조회 api 연결
- 내 정보 수정 api 연결
- 로그아웃 api 연결

### 🔑 주요 변경사항

- 내 정보 조회: 닉네임, 이메일 읽기 전용 모드로 확인 가능
- 내 정보 수정: 닉네임, 비밀번호 수정 가능
- 로그아웃 후 localStorage에 access_token, refresh_token 삭제

### 🏞 테스트 결과


https://github.com/user-attachments/assets/a2f74498-3278-411f-830b-6d407c37f288


![image](https://github.com/user-attachments/assets/dc7c1b36-7597-4b25-912a-8650905bd399)



### 🗨️ 리뷰 요구사항 또는 개인 코멘트

- 어제 회의 통해서 patch 할 때 CORS 에러 해결 되었습니다.